### PR TITLE
CI: restore analysis

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -10,9 +10,9 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      # - name: Git checkout
-      #   uses: actions/checkout@v2
-      # - name: Analyze package
-      #   uses: axel-op/dart-package-analyzer@v3
-      #   with:
-      #     githubToken: ${{secrets.GITHUB_TOKEN}}
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Analyze package
+        uses: axel-op/dart-package-analyzer@v3
+        with:
+          githubToken: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
It was disabled due to unstable Dart SDK dependency, but 2.14 has made
its to the stable channel a long ago.